### PR TITLE
Revamp gallery modal with share and download controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,18 +75,22 @@ function renderGrid(){
   const grid = byId('grid');
   grid.innerHTML='';
 
-  // Only show non-featured images in main grid
-  const regularImages = filtered.filter(item => item.featured !== true);
-  
-  // Add section header for regular images
-  if (regularImages.length > 0 && DATA.some(item => item.featured === true)) {
+  const hasFeatured = filtered.some(item => item.featured === true);
+  let regularImages = filtered.filter(item => item.featured !== true);
+
+  // When every image is marked as featured fall back to showing them all
+  if (!regularImages.length) {
+    regularImages = filtered;
+  }
+
+  if (regularImages.length && hasFeatured && regularImages.length !== filtered.length) {
     const header = document.createElement('h2');
     header.textContent = '📁 Gallery Collection';
     header.style.marginBottom = '1.5rem';
     header.style.fontSize = '1.5rem';
     grid.appendChild(header);
   }
-  
+
   regularImages.forEach(item => {
     const card = createImageCard(item);
     grid.appendChild(card);

--- a/app.js
+++ b/app.js
@@ -17,7 +17,6 @@ async function loadAll(){
   filtered = [...DATA];
   hydrateTagFilter();
   renderFeatured();
-  renderPrimoImages();  // Primo pictures at top
   renderGrid();
   handleHashOpen();
 }
@@ -68,73 +67,14 @@ function createImageCard(item){
   img.className='thumb'; img.loading='lazy'; img.src=item.thumb || item.src; img.alt=item.title || item.file || '';
   img.onerror=()=>{ img.src=item.src; };
   card.appendChild(img);
-  const pad = document.createElement('div'); pad.className='pad';
-  const h3 = document.createElement('h3'); h3.textContent = item.title || item.file;
-  pad.appendChild(h3);
-  const caption = document.createElement('p'); caption.textContent = item.caption || ''; caption.style.opacity=.85; caption.style.margin='0 0 .4rem';
-  pad.appendChild(caption);
-  const tags = document.createElement('div'); tags.className='tags';
-  (item.tags||[]).forEach(t=>{ const span=document.createElement('span'); span.className='tag'; span.textContent=t; span.onclick=(e)=>{e.stopPropagation(); filterByTag(t);} ; tags.appendChild(span);});
-  pad.appendChild(tags);
-  const actions=document.createElement('div'); actions.className='actions';
-  const viewBtn=document.createElement('a'); viewBtn.className='btn'; viewBtn.textContent='View'; viewBtn.href='#'+(item.id||slug(item.file)); viewBtn.onclick=(e)=>{e.preventDefault(); openModal(item);};
-  const openBtn=document.createElement('a'); openBtn.className='btn secondary'; openBtn.textContent='Open Image'; openBtn.href=item.src; openBtn.target='_blank';
-  actions.appendChild(viewBtn); actions.appendChild(openBtn); pad.appendChild(actions);
   card.onclick=()=>openModal(item);
-  card.appendChild(pad);
   return card;
-}
-
-function renderPrimoImages(){
-  const primoImages = DATA.filter(item => item.featured === true);
-  if (!primoImages.length) return;
-  
-  const grid = byId('grid');
-  
-  // Create primo section
-  const primoSection = document.createElement('section');
-  primoSection.className = 'primo-section';
-  primoSection.style.marginBottom = '3rem';
-  
-  const header = document.createElement('div');
-  header.style.display = 'flex';
-  header.style.justifyContent = 'space-between';
-  header.style.alignItems = 'center';
-  header.style.marginBottom = '1.5rem';
-  
-  const title = document.createElement('h2');
-  title.textContent = '⭐ Featured Visualizations';
-  title.style.margin = '0';
-  title.style.fontSize = '1.5rem';
-  
-  const count = document.createElement('span');
-  count.className = 'muted';
-  count.textContent = `${primoImages.length} primo images`;
-  
-  header.appendChild(title);
-  header.appendChild(count);
-  primoSection.appendChild(header);
-  
-  // Create grid for primo images
-  const primoGrid = document.createElement('div');
-  primoGrid.className = 'grid';
-  primoGrid.style.gridTemplateColumns = 'repeat(auto-fit, minmax(280px, 1fr))';
-  primoGrid.style.gap = '1.5rem';
-  primoGrid.style.padding = '0';
-  
-  primoImages.forEach(item => {
-    const card = createImageCard(item);
-    primoGrid.appendChild(card);
-  });
-  
-  primoSection.appendChild(primoGrid);
-  grid.before(primoSection);
 }
 
 function renderGrid(){
   const grid = byId('grid');
   grid.innerHTML='';
-  
+
   // Only show non-featured images in main grid
   const regularImages = filtered.filter(item => item.featured !== true);
   
@@ -155,6 +95,22 @@ function renderGrid(){
 
 function slug(s){ return (s||'').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,''); }
 
+let shareStatusTimer = null;
+
+function setShareStatus(message, isError=false){
+  const status = byId('modalShareStatus');
+  if(!status) return;
+  status.textContent = message;
+  status.classList.toggle('error', !!isError);
+  if(shareStatusTimer){ clearTimeout(shareStatusTimer); }
+  if(message){
+    shareStatusTimer = setTimeout(()=>{
+      status.textContent='';
+      status.classList.remove('error');
+    }, 4000);
+  }
+}
+
 function openModal(item){
   history.replaceState(null,'','#'+(item.id || slug(item.file)));
   const m = byId('modal');
@@ -167,6 +123,48 @@ function openModal(item){
   (item.tags||[]).forEach(t=>{ const span=document.createElement('span'); span.className='tag'; span.textContent=t; tagBox.appendChild(span);});
   const sib = byId('modalSiblings'); sib.innerHTML='';
   DATA.slice(0,10).forEach(s=>{ const a=document.createElement('a'); a.href='#'+(s.id||slug(s.file)); a.textContent=(s.title||s.file).slice(0,24); a.onclick=(e)=>{e.preventDefault(); openModal(s);} ; sib.appendChild(a); });
+
+  const shareLink = `${location.origin}${location.pathname}#${item.id || slug(item.file)}`;
+  const shareInput = byId('modalShareLink');
+  if(shareInput){
+    shareInput.value = shareLink;
+    shareInput.onclick = ()=>shareInput.select();
+  }
+  const shareBtn = byId('modalShare');
+  if(shareBtn){
+    shareBtn.onclick = async ()=>{
+      try{
+        if(navigator.share){
+          await navigator.share({title:item.title||item.file,url:shareLink});
+          setShareStatus('Share dialog opened.');
+        }else if(navigator.clipboard && navigator.clipboard.writeText){
+          await navigator.clipboard.writeText(shareLink);
+          setShareStatus('Link copied to clipboard.');
+        }else{
+          if(shareInput){
+            shareInput.focus();
+            shareInput.select();
+            document.execCommand('copy');
+            setShareStatus('Link copied to clipboard.');
+          }
+        }
+      }catch(err){
+        console.error('Share failed', err);
+        setShareStatus('Unable to share this image.', true);
+      }
+    };
+  }
+  const downloadBtn = byId('modalDownload');
+  if(downloadBtn){
+    downloadBtn.href = item.src;
+    downloadBtn.download = item.file || `${slug(item.title||'image')}.png`;
+  }
+  const fullBtn = byId('modalOpenFull');
+  if(fullBtn){
+    fullBtn.href = item.src;
+  }
+
+  setShareStatus('');
   m.classList.remove('hidden'); m.setAttribute('aria-hidden','false');
 }
 function closeModal(){ const m=byId('modal'); m.classList.add('hidden'); m.setAttribute('aria-hidden','true'); }

--- a/collections/index.html
+++ b/collections/index.html
@@ -48,6 +48,13 @@
         <div id="modalTags" class="tags"></div>
         <div class="meta-pair"><span>File:</span><code id="modalFile"></code></div>
         <div class="meta-pair"><span>Created:</span><span id="modalCreated"></span></div>
+        <div class="modal-actions">
+          <button id="modalShare" class="btn" type="button">Share Link</button>
+          <a id="modalDownload" class="btn secondary" href="#" download>Download</a>
+          <a id="modalOpenFull" class="btn secondary" href="#" target="_blank" rel="noopener">Open Full Page</a>
+        </div>
+        <input id="modalShareLink" class="share-link" type="text" readonly aria-label="Shareable link for this image" />
+        <div id="modalShareStatus" class="share-status" role="status" aria-live="polite"></div>
       </div>
       <div id="modalSiblings" class="siblings"></div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -37,37 +37,44 @@ body{
 .badges{display:flex;gap:.4rem;flex-wrap:wrap;margin:.4rem 0}
 .badge{font-size:.72rem;background:rgba(255,255,255,0.08);border:1px solid var(--border);padding:.2rem .5rem;border-radius:.5rem}
 .badge.gold{background:linear-gradient(135deg,var(--accent1),var(--accent3));color:#222}
-.grid{max-width:1200px;margin:0 auto 4rem;padding:1rem;display:grid;grid-template-columns:repeat(2,1fr);gap:1rem}
-@media (max-width:900px){.grid{grid-template-columns:1fr}}
+.grid{max-width:1200px;margin:0 auto 4rem;padding:1rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1.2rem}
 
-.card{background:var(--card);border:1px solid var(--border);border-radius:1rem;overflow:hidden;display:flex;flex-direction:column}
+.card{background:var(--card);border:1px solid var(--border);border-radius:1rem;overflow:hidden;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease}
+.card:hover{transform:translateY(-4px);box-shadow:0 16px 32px rgba(0,0,0,0.4)}
 .thumb{aspect-ratio:16/10;object-fit:cover;width:100%;display:block}
-.card .pad{padding:.8rem}
-.card h3{margin:.2rem 0 .4rem;font-size:1rem}
 .tags{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.4rem}
 .tag{font-size:.75rem;background:rgba(255,255,255,0.08);border:1px solid var(--border);padding:.2rem .5rem;border-radius:.5rem}
-.actions{display:flex;gap:.5rem;margin-top:.6rem}
 .btn{
   flex:1;text-align:center;text-decoration:none;color:var(--fg);
   background:linear-gradient(135deg,var(--accent1),var(--accent2));
-  padding:.5rem .8rem;border-radius:.6rem;border:1px solid var(--border)
+  padding:.55rem .9rem;border-radius:.6rem;border:1px solid var(--border);
+  display:inline-flex;align-items:center;justify-content:center;gap:.35rem;
+  cursor:pointer;font:inherit;
 }
+.btn:hover{filter:brightness(1.05)}
 .btn.secondary{background:transparent}
+.btn:focus-visible{outline:2px solid var(--accent3);outline-offset:2px}
 
 .modal.hidden{display:none}
 .modal{position:fixed;inset:0;z-index:50}
 .modal-backdrop{position:absolute;inset:0;background:rgba(0,0,0,0.6)}
 .modal-card{
-  position:relative; max-width:1100px; margin:4vh auto; background:var(--bg2);
+  position:relative; width:min(1200px,96vw); height:min(92vh,96vh); margin:2vh auto; background:var(--bg2);
   border:1px solid var(--border); border-radius:1rem; overflow:hidden; display:grid;
-  grid-template-columns: 2fr 1fr; gap:0; box-shadow:0 20px 50px rgba(0,0,0,.5)
+  grid-template-columns:minmax(0,2fr) minmax(0,1fr); gap:0; box-shadow:0 20px 50px rgba(0,0,0,.6)
 }
 @media (max-width:900px){.modal-card{grid-template-columns:1fr}}
 .modal-card img{width:100%; height:100%; object-fit:contain; background:var(--bg1)}
-.meta{padding:1rem;border-left:1px solid var(--border)}
+.meta{padding:1rem;border-left:1px solid var(--border);overflow:auto}
 .meta h2{margin:.2rem 0 .4rem}
 .meta p{margin:.2rem 0 .8rem;color:var(--muted)}
 .meta .meta-pair{display:flex;gap:.6rem;align-items:center;margin:.2rem 0;color:var(--muted)}
+.modal-actions{display:flex;gap:.5rem;margin:1rem 0 .6rem;flex-wrap:wrap}
+.modal-actions .btn{flex:1 1 48%}
+.share-link{width:100%;background:rgba(255,255,255,0.05);border:1px solid var(--border);border-radius:.5rem;padding:.5rem .75rem;color:var(--fg);font-family:monospace;font-size:.85rem}
+.share-link:focus-visible{outline:2px solid var(--accent3);outline-offset:2px}
+.share-status{margin-top:.4rem;font-size:.85rem;color:var(--muted);min-height:1.2em}
+.share-status.error{color:var(--accent4)}
 .close{
   position:absolute;top:.6rem;right:.6rem;background:rgba(0,0,0,0.5);
   color:#fff;border:1px solid var(--border);border-radius:.5rem;padding:.2rem .5rem;font-size:1.1rem;cursor:pointer


### PR DESCRIPTION
## Summary
- remove text overlays and card buttons so the gallery grid showcases just the artwork
- add modal actions for sharing unique links, downloading the original, and opening the full image
- refresh gallery styling so the modal fills the page and the controls support the new workflow

## Testing
- not run (static files)


------
https://chatgpt.com/codex/tasks/task_e_68e615e807108331b2588511b76f7e1a